### PR TITLE
csproj-6 Add skeleton class for ManagedObject

### DIFF
--- a/src/MaybeManaged/IManagedObject.cs
+++ b/src/MaybeManaged/IManagedObject.cs
@@ -48,7 +48,7 @@ public interface IManagedObject<T> : IDisposable
     /// the managed object if owned; otherwise default value of <typeparamref name="T"/>
     /// which will be <see langword="null"/> for reference types
     /// </returns>
-    T? Value();
+    T? Value { get; }
 
     /// <summary>
     /// Returns <see langword="true"/> if <see cref="Value"/> is currently owned.

--- a/src/MaybeManaged/IMaybeManagedObject.cs
+++ b/src/MaybeManaged/IMaybeManagedObject.cs
@@ -17,7 +17,7 @@ namespace TSMoreland.MaybeManaged;
 /// Container class storing at most 1 item, and is responsible for the disposal of that item if present
 /// </summary>
 /// <typeparam name="T">The type of the stored value</typeparam>
-public interface IMaybeOwned<T> : IDisposable
+public interface IMaybeManagedObject<T> : IDisposable
     where T : IDisposable
 {
     /// <summary>
@@ -75,7 +75,7 @@ public interface IMaybeOwned<T> : IDisposable
     /// If a value is present, apply the
     /// provided Maybe-bearing mapping function to it,
     /// return that result, otherwise return
-    /// an empty <see cref="IMaybeOwned{T}"/>.
+    /// an empty <see cref="IMaybeManagedObject{T}"/>.
     /// </summary>
     /// <typeparam name="TMapped"></typeparam>
     /// <param name="mapper">
@@ -83,8 +83,8 @@ public interface IMaybeOwned<T> : IDisposable
     /// should not dispose the owned type as that remains the responsibility of this instance
     /// </param>
     /// <returns>
-    /// <see cref="IMaybeOwned{TMapped}"/> containing mapped result if present for this instance;
-    /// otherwise an empty <see cref="IMaybeOwned{TMapped}"/>
+    /// <see cref="IMaybeManagedObject{TMapped}"/> containing mapped result if present for this instance;
+    /// otherwise an empty <see cref="IMaybeManagedObject{TMapped}"/>
     /// </returns>
-    IMaybeOwned<TMapped> Map<TMapped>(Func<T, TMapped> mapper) where TMapped : IDisposable;
+    IMaybeManagedObject<TMapped> Map<TMapped>(Func<T, TMapped> mapper) where TMapped : IDisposable;
 }

--- a/src/MaybeManaged/ManagedObject.cs
+++ b/src/MaybeManaged/ManagedObject.cs
@@ -14,64 +14,51 @@
 namespace TSMoreland.MaybeManaged;
 
 /// <summary>
-/// Factory methods for <see cref="MaybeOwned{T}"/>
+/// Manages a <typeparamref name="T"/> if this instance is the current owner making it responsible
+/// for the disposal of the owned object
 /// </summary>
-public static class MaybeOwned
-{
-    /// <summary>
-    /// Creates an instance of <see cref="MaybeOwned{T}"/> containing <paramref name="value"/>
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="value"></param>
-    /// <returns></returns>
-    public static MaybeOwned<T> Of<T>(T value) where T : IDisposable
-    {
-        return new MaybeOwned<T>(true, value);
-    }
-
-    /// <summary>
-    /// Creates an empty instance of <see cref="MaybeOwned{T}"/>
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <returns>an empty instance of <see cref="MaybeOwned{T}"/></returns>
-    public static MaybeOwned<T> Empty<T>() where T : IDisposable =>
-        new();
-}
-
-public struct MaybeOwned<T> : IMaybeOwned<T>
+/// <typeparam name="T">
+/// <see cref="IDisposable"/> object which will be disposed when this instance is, unless ownership is transfer
+/// </typeparam>
+public sealed class ManagedObject<T> : IManagedObject<T>
     where T : IDisposable
 {
-    public MaybeOwned()
-        :this(false, default)
+    /// <summary>
+    /// Instanties a new instance of <see cref="ManagedObject{T}"/> that does not
+    /// own an object of type <typeparamref name="T"/>
+    /// </summary>
+    public ManagedObject()
+        : this(false, default)
     {
     }
 
-    internal MaybeOwned(bool hasValue, T? value)
+    /// <summary>
+    /// Instanties a new instance of <see cref="ManagedObject{T}"/> that owns
+    /// <paramref name="value"/>
+    /// </summary>
+    /// <param name="value">the object to be managed by this instance.</param>
+    public ManagedObject(T value)
+        : this(true, value)
     {
-        HasValue = hasValue;
+    }
+
+    private ManagedObject(bool hasValue, T? value)
+    {
+        HasValue =  hasValue;
         Value = value;
     }
 
     /// <inheritdoc />
-    public bool HasValue { get; private set; }
+    public void Reset(T? value = default) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public T? Release() => throw new NotImplementedException();
 
     /// <inheritdoc />
     public T? Value { get; private set; }
 
     /// <inheritdoc />
-    public readonly T OrElse(T other) => throw new NotImplementedException();
-
-    /// <inheritdoc />
-    public readonly T OrElse(Func<T> supplier) => throw new NotImplementedException();
-
-    /// <inheritdoc />
-    public T OrThrow() => throw new NotImplementedException();
-
-    /// <inheritdoc />
-    public T OrThrow(Func<Exception> supplier) => throw new NotImplementedException();
-
-    /// <inheritdoc />
-    public IMaybeOwned<TMapped> Map<TMapped>(Func<T, TMapped> mapper) where TMapped : IDisposable => throw new NotImplementedException();
+    public bool HasValue { get; private set; }
 
     /// <inheritdoc />
     public void Dispose() => throw new NotImplementedException();

--- a/src/MaybeManaged/MaybeManagedObject.cs
+++ b/src/MaybeManaged/MaybeManagedObject.cs
@@ -1,0 +1,78 @@
+﻿//
+// Copyright © 2022 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace TSMoreland.MaybeManaged;
+
+/// <summary>
+/// Factory methods for <see cref="MaybeOwned{T}"/>
+/// </summary>
+public static class MaybeManagedObject
+{
+    /// <summary>
+    /// Creates an instance of <see cref="MaybeOwned{T}"/> containing <paramref name="value"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public static MaybeOwned<T> Of<T>(T value) where T : IDisposable
+    {
+        return new MaybeOwned<T>(true, value);
+    }
+
+    /// <summary>
+    /// Creates an empty instance of <see cref="MaybeOwned{T}"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns>an empty instance of <see cref="MaybeOwned{T}"/></returns>
+    public static MaybeOwned<T> Empty<T>() where T : IDisposable =>
+        new();
+}
+
+public struct MaybeOwned<T> : IMaybeManagedObject<T>
+    where T : IDisposable
+{
+    public MaybeOwned()
+        :this(false, default)
+    {
+    }
+
+    internal MaybeOwned(bool hasValue, T? value)
+    {
+        HasValue = hasValue;
+        Value = value;
+    }
+
+    /// <inheritdoc />
+    public bool HasValue { get; private set; }
+
+    /// <inheritdoc />
+    public T? Value { get; private set; }
+
+    /// <inheritdoc />
+    public readonly T OrElse(T other) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public readonly T OrElse(Func<T> supplier) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public T OrThrow() => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public T OrThrow(Func<Exception> supplier) => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public IMaybeManagedObject<TMapped> Map<TMapped>(Func<T, TMapped> mapper) where TMapped : IDisposable => throw new NotImplementedException();
+
+    /// <inheritdoc />
+    public void Dispose() => throw new NotImplementedException();
+}


### PR DESCRIPTION
Closes #6 

## Changes

- add initial implementation of IManagedObject
- correct Value property in IManagedObject - it should be a property

## Testing
- none yet, this is just adding the first implementation to be used by tests 
